### PR TITLE
修复添加或编辑后台菜单auth_rule表数据未新增或更新问题

### DIFF
--- a/application/Admin/Controller/MenuController.class.php
+++ b/application/Admin/Controller/MenuController.class.php
@@ -114,7 +114,7 @@ class MenuController extends AdminbaseController {
     				$menu_name=I("post.name");
     				$mwhere=array("name"=>$name);
     				
-    				$find_rule_count=$this->auth_rule_model->where($mwhere)->count();
+    				$find_rule_count=(int)$this->auth_rule_model->where($mwhere)->count();
     				if($find_rule_count===0){
     					$this->auth_rule_model->add(array("name"=>$name,"module"=>$app,"type"=>"admin_url","title"=>$menu_name));//type 1-admin rule;2-user rule
     				}
@@ -181,7 +181,7 @@ class MenuController extends AdminbaseController {
     				$menu_name=I("post.name");
     				$mwhere=array("name"=>$name);
     				
-    				$find_rule_count=$this->auth_rule_model->where($mwhere)->count();
+    				$find_rule_count=(int)$this->auth_rule_model->where($mwhere)->count();
     				if($find_rule_count===0){
     					$this->auth_rule_model->add(array("name"=>$name,"module"=>$app,"type"=>"admin_url","title"=>$menu_name));//type 1-admin rule;2-user rule
     				}else{


### PR DESCRIPTION
thinkPHP的model->count()返回值为string类型，导致if($find_rule_count===0)结果总为false