### PR TITLE
修复添加url美化规则后出现无法加载控制器问题

### DIFF
--- a/application/Common/Common/function.php
+++ b/application/Common/Common/function.php
@@ -1528,8 +1528,8 @@ function sp_get_routes($refresh=false){
 	}
 
 	$route_file=$route_dir."route.php";
-
-	file_put_contents($route_file, "<?php\treturn " . stripslashes(var_export($all_routes, true)) . ";");
+	$all['URL_ROUTE_RULES']=$all_routes;
+	file_put_contents($route_file, "<?php\treturn " . stripslashes(var_export($all, true)) . ";");
 
 	return $cache_routes;
 


### PR DESCRIPTION
修改之前保存路由规则结果如下:
```php
<?php
return array(
    'list/:id\d' => 'portal/list/index',
    'register' => 'user/Register/index',
);
```


修改之后保存路由规则结果如下:
```php
<?php	return array (
  'URL_ROUTE_RULES' => array (
    'list/:id\d' => 'portal/list/index',
    'register' => 'user/Register/index',
  ),
);```
